### PR TITLE
feat: add juju 3.1 support for functests

### DIFF
--- a/.github/workflows/_func.yaml
+++ b/.github/workflows/_func.yaml
@@ -33,16 +33,9 @@ on:
         default: false
       commands:
         required: false
-        description: |
-          Command to run functional tests in strategies. It defaults to
-          `make functional`, but is defined as a list, so `['make functional']`.
-          This allows you to run multiple tests with different parameters.
-          Examples:
-          - ['FUNC_ARGS="--series jammy" make functional',
-             'FUNC_ARGS="--series focal" make functional']
-          - ['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']
+        description: "Command to run functional tests with"
         type: string
-        default: "['make functional']"
+        default: "make functional"
       # actions-operator
       provider:
         required: false
@@ -62,10 +55,6 @@ jobs:
     name: Functional tests
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    strategy:
-      fail-fast: true
-      matrix:
-        command: ${{ fromJson(inputs.commands) }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -78,7 +67,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install "tox${{ inputs.tox-version }}"
-      - name: Setup Juju environment
+      - name: Setup Juju ${{ inputs.juju-channel }} environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: ${{ inputs.provider }}
@@ -99,6 +88,6 @@ jobs:
           lxc profile set --project nested-lxd default security.privileged=true
           # set default project to be nested-lxd project
           juju model-default project=nested-lxd
-      - name: Run tests with `${{ matrix.command }}`
+      - name: Run tests with `${{ inputs.commands }}`
         working-directory: ${{ inputs.working-directory }}
-        run: ${{ matrix.command }}
+        run: ${{ inputs.commands }}

--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -44,15 +44,7 @@ on:
         default: "."
       commands:
         required: true
-        description: |
-          Command to run functional test in strategies. It accepts a stringified list
-          of commands, which allows you to run multiple tests with different parameters.
-          This is a required input field.
-          Examples:
-          - "['make functional']"
-          - "['FUNC_ARGS="--series jammy" make functional',
-             'FUNC_ARGS="--series focal" make functional']"
-          - "['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']"
+        description: "Command to run functional test with"
         type: string
       juju-channel:
         required: false

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -38,15 +38,7 @@ on:
         default: 60
       commands:
         required: true
-        description: |
-          Command to run functional tests in strategies. It accepts a stringified list
-          of commands, which allows you to run multiple tests with different parameters.
-          This is a required input field.
-          Examples:
-          - "['make functional']"
-          - "['FUNC_ARGS="--series jammy" make functional',
-             'FUNC_ARGS="--series focal" make functional']"
-          - "['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']"
+        description: "Command to run functional tests with"
         type: string
       juju-channel:
         required: false

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -41,15 +41,7 @@ on:
         default: true
       commands:
         required: true
-        description: |
-          Command to run functional tests in strategies. It accepts a stringified list
-          of commands, which allows you to run multiple tests with different parameters.
-          This is a required input field.
-          Examples:
-          - "['make functional']"
-          - "['FUNC_ARGS="--series jammy" make functional',
-             'FUNC_ARGS="--series focal" make functional']"
-          - "['tox -e func -- -sv --series jammy', 'tox -e func -- -sv --series focal']"
+        description: "Command to run functional tests with"
         type: string
       timeout-minutes:
         required: false

--- a/.github/workflows/test-func.yaml
+++ b/.github/workflows/test-func.yaml
@@ -11,15 +11,23 @@ jobs:
   charm-func:
     uses: ./.github/workflows/_func.yaml
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - commands: "make functional"
+            juju-channel: "2.9/stable"
+          - commands: "make functional31"
+            juju-channel: "3.1/stable"
     with:
       python-version: "3.10"
       tox-version: "<4"
       working-directory: ./tests/test_charm_repo
-      commands: "['FUNC_ARGS=\"--series jammy\" make functional']"
+      commands: ${{ matrix.commands }}
       timeout-minutes: 120
       provider: "lxd"
       nested-containers: true
-      juju-channel: "2.9/stable"
+      juju-channel: ${{ matrix.juju-channel }}
 
   snap-func:
     uses: ./.github/workflows/_func.yaml

--- a/.github/workflows/test-pull-request.yaml
+++ b/.github/workflows/test-pull-request.yaml
@@ -14,13 +14,21 @@ jobs:
   charm-pr:
     uses: ./.github/workflows/pull-request.yaml
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - commands: "FUNC_ARGS=\"--series jammy\" make functional"
+            juju-channel: "2.9/stable"
+          - commands: "FUNC_ARGS=\"--series jammy\" make functional31"
+            juju-channel: "3.1/stable"
     with:
       python-version-unit: "['3.10']"
       python-version-func: "3.10"
       tox-version: "<4"
       working-directory: ./tests/test_charm_repo
-      commands: "['FUNC_ARGS=\"--series jammy\" make functional']"
-      juju-channel: "2.9/stable"
+      commands: ${{ matrix.commands }}
+      juju-channel: ${{ matrix.juju-channel }}
 
   snap-pr:
     uses: ./.github/workflows/pull-request.yaml
@@ -31,4 +39,4 @@ jobs:
       tox-version: "<4"
       working-directory: ./tests/test_snap_repo
       snapcraft: true
-      commands: "['make functional']"
+      commands: "make functional"

--- a/tests/test_charm_repo/Makefile
+++ b/tests/test_charm_repo/Makefile
@@ -24,6 +24,7 @@ help:
 	@echo " make reformat - run black and isort and reformat files"
 	@echo " make unittests - run the tests defined in the unittest subdirectory"
 	@echo " make functional - run the tests defined in the functional subdirectory"
+	@echo " make functional31 - run the tests defined in the functional subdirectory with juju 3.1 requirements"
 	@echo " make test - run lint, unittests and functional targets"
 	@echo ""
 
@@ -76,8 +77,12 @@ functional:
 	@echo "Executing functional tests using built charm at ${PROJECTPATH}"
 	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
 
+functional31:
+	@echo "Executing functional tests using built charm at ${PROJECTPATH} with juju 3.1 requirements"
+	@CHARM_LOCATION=${PROJECTPATH} tox -e func31 -- ${FUNC_ARGS}
+
 test: lint unittests functional
 	@echo "Tests completed for charm ${CHARM_NAME}."
 
 # The targets below don't depend on a file
-.PHONY: help dev-environment pre-commit submodules submodules-update clean build lint reformat unittests functional
+.PHONY: help dev-environment pre-commit submodules submodules-update clean build lint reformat unittests functional functional31

--- a/tests/test_charm_repo/tox.ini
+++ b/tests/test_charm_repo/tox.ini
@@ -82,4 +82,11 @@ commands = pytest {toxinidir}/tests/functional {posargs:-v}
 deps =
   pytest
   pytest-operator
-  -r {toxinidir}/tests/functional/requirements.txt
+  juju<3
+
+[testenv:func31]
+commands = pytest {toxinidir}/tests/functional {posargs:-v}
+deps =
+  pytest
+  pytest-operator
+  juju


### PR DESCRIPTION
Starting from this change, the pull-request and charm-release workflow gives responsibility of creating the command x juju-target matrix to the user.